### PR TITLE
Add dated grade support and silent materie

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ add_executable(ProiectC_
         Absente.h
         Materie.cpp
         Materie.h
+        Nota.cpp
+        Nota.h
         IO.cpp
         IO.h
 )

--- a/Elev.cpp
+++ b/Elev.cpp
@@ -43,20 +43,22 @@ void Elev::motiveazaAbsenta(const string data, const string materie) {
     cout << "Nu s-a gasit materia sau absenta\n";
 }
 
-void Elev::adaugaNota(const int nota, const string materie) {
+void Elev::adaugaNota(int nota, const string& materie, const string& data) {
     for (auto& i : materii) {
         if (i.nume == materie) {
-            i.note.push_back(nota);
+            i.addNota(nota, data);
             return;
         }
     }
     cout << "Nu s-a gasit materia\n";
 }
 
-void Elev::stergeNota(const int nota, const string materie) {
+void Elev::stergeNota(int nota, const string& materie, const string& data) {
     for (auto& i : materii) {
         if (i.nume == materie) {
-            auto it = find(i.note.begin(), i.note.end(), nota);
+            auto it = std::find_if(i.note.begin(), i.note.end(), [&](const Nota& n){
+                return n.valoare == nota && (data.empty() || n.data == data);
+            });
             if (it != i.note.end()) {
                 i.note.erase(it);
             } else {
@@ -68,7 +70,7 @@ void Elev::stergeNota(const int nota, const string materie) {
     cout << "Nu s-a gasit materia\n";
 }
 
-void Elev::adaugaMaterie(const string& numeMaterie) {
+void Elev::adaugaMaterie(const string& numeMaterie, bool silent) {
     for (const auto& m : materii) {
         if (m.nume == numeMaterie) {
             cout << "Materia " << numeMaterie << " exista deja.\n";
@@ -76,7 +78,8 @@ void Elev::adaugaMaterie(const string& numeMaterie) {
         }
     }
     materii.emplace_back(numeMaterie);
-    cout << "Materia " << numeMaterie << " a fost adaugata elevului " << nume << " " << prenume << ".\n";
+    if (!silent)
+        cout << "Materia " << numeMaterie << " a fost adaugata elevului " << nume << " " << prenume << ".\n";
 }
 
 void Elev::stergeMaterie(const string& numeMaterie) {

--- a/Elev.h
+++ b/Elev.h
@@ -26,9 +26,9 @@ public:
     };
     void adaugaAbsenta(string,string);
     void motiveazaAbsenta(string,string);
-    void adaugaNota(const int nota,const string materie);
-    void stergeNota(const int nota,const string materie);
-    void adaugaMaterie(const string& numeMaterie);
+    void adaugaNota(int nota, const string& materie, const string& data="");
+    void stergeNota(int nota, const string& materie, const string& data="");
+    void adaugaMaterie(const string& numeMaterie, bool silent=false);
     void stergeMaterie(const string& numeMaterie);
     string getCNP() const{ return cnp; };
     const vector<Materie>& getMaterii() const {

--- a/IO.cpp
+++ b/IO.cpp
@@ -50,12 +50,21 @@ void citesteMaterii(const string& numeFisier) {
         if (pos != string::npos) {
             absenteStr = linie.substr(pos + 8);
         }
-        elev->adaugaNota(-1, materie); // for init only
+        elev->adaugaMaterie(materie, true);
         if (!noteStr.empty()) {
             istringstream noteSS(noteStr);
             string nota;
             while (getline(noteSS, nota, ',')) {
-                if (!nota.empty()) elev->adaugaNota(stoi(nota), materie);
+                if (!nota.empty()) {
+                    string valPart = nota;
+                    string dataPart;
+                    size_t col = nota.find(':');
+                    if (col != string::npos) {
+                        valPart = nota.substr(0, col);
+                        dataPart = nota.substr(col + 1);
+                    }
+                    elev->adaugaNota(stoi(valPart), materie, dataPart);
+                }
             }
         }
         if (!absenteStr.empty()) {
@@ -95,7 +104,8 @@ void scrieMaterii(const string& numeFisier) {
         for (const auto& m : e.getMaterii()) {
             out << cnp << " " << m.nume << " note:";
             for (size_t i = 0; i < m.note.size(); i++) {
-                out << m.note[i];
+                out << m.note[i].valoare;
+                if (!m.note[i].data.empty()) out << ":" << m.note[i].data;
                 if (i + 1 < m.note.size()) out << ",";
             }
             out << " absente:";
@@ -139,7 +149,7 @@ void citesteTotCatalogul() {
 
             if (linie.rfind("Materie:", 0) == 0) {
                 string materie = linie.substr(9);
-                elev.adaugaMaterie(materie);
+                elev.adaugaMaterie(materie, true);
 
                 getline(in, linie); // Note:
                 if (linie.rfind("Note:", 0) == 0) {
@@ -147,8 +157,16 @@ void citesteTotCatalogul() {
                     istringstream ss(noteStr);
                     string nota;
                     while (getline(ss, nota, ',')) {
-                        if (!nota.empty())
-                            elev.adaugaNota(stoi(nota), materie);
+                        if (!nota.empty()) {
+                            string valPart = nota;
+                            string dataPart;
+                            size_t col = nota.find(':');
+                            if (col != string::npos) {
+                                valPart = nota.substr(0, col);
+                                dataPart = nota.substr(col + 1);
+                            }
+                            elev.adaugaNota(stoi(valPart), materie, dataPart);
+                        }
                     }
                 }
 
@@ -190,7 +208,8 @@ void scrieElevIndividual(const Elev& e) {
 
         out << "Note: ";
         for (size_t i = 0; i < m.note.size(); ++i) {
-            out << m.note[i];
+            out << m.note[i].valoare;
+            if (!m.note[i].data.empty()) out << ":" << m.note[i].data;
             if (i + 1 < m.note.size()) out << ",";
         }
         out << "\n";

--- a/Materie.cpp
+++ b/Materie.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "Materie.h"
+#include "Nota.h"
 #include <algorithm>
 
 Materie::Materie(string a) {
@@ -18,5 +19,18 @@ void Materie::delAbsenta(string data) {
         [&](const Absente& a) { return a.data == data; });
     if (it != abs.end()) {
         abs.erase(it);
+    }
+}
+
+void Materie::addNota(int valoare, const string& data) {
+    note.emplace_back(valoare, data);
+}
+
+void Materie::delNota(int valoare, const string& data) {
+    auto it = std::find_if(note.begin(), note.end(), [&](const Nota& n){
+        return n.valoare == valoare && (data.empty() || n.data == data);
+    });
+    if (it != note.end()) {
+        note.erase(it);
     }
 }

--- a/Materie.h
+++ b/Materie.h
@@ -5,16 +5,19 @@
 #ifndef MATERIE_H
 #define MATERIE_H
 #include "Absente.h"
+#include "Nota.h"
 #include <vector>
 
 class Materie {
     public:
     string nume;
     vector<Absente> abs;
-    vector<int>note;
+    vector<Nota> note;
     Materie(string);
     void addAbsenta(string);
     void delAbsenta(string);
+    void addNota(int valoare, const string& data="");
+    void delNota(int valoare, const string& data="");
 };
 
 

--- a/Nota.cpp
+++ b/Nota.cpp
@@ -1,0 +1,2 @@
+#include "Nota.h"
+Nota::Nota(int valoare, const std::string& data) : valoare(valoare), data(data) {}

--- a/Nota.h
+++ b/Nota.h
@@ -1,0 +1,10 @@
+#ifndef NOTA_H
+#define NOTA_H
+#include <string>
+class Nota {
+public:
+    int valoare;
+    std::string data;
+    Nota(int valoare = 0, const std::string& data = "");
+};
+#endif // NOTA_H

--- a/main.cpp
+++ b/main.cpp
@@ -165,7 +165,11 @@ int main(int argc, char* argv[]) {
             for (const auto& m : elev.getMaterii()) {
                 cout << "  Materie: " << m.nume << "\n";
                 cout << "    Note: ";
-                for (int n : m.note) cout << n << " ";
+                for (const auto& n : m.note) {
+                    cout << n.valoare;
+                    if (!n.data.empty()) cout << ":" << n.data;
+                    cout << " ";
+                }
                 cout << "\n    Absente: ";
                 for (const auto& a : m.abs)
                     cout << a.data << (a.motivat ? "*" : "") << " ";


### PR DESCRIPTION
## Summary
- create new `Nota` class for storing grades with a date
- update `Materie` and `Elev` to use `Nota` objects
- suppress messages when loading subjects by adding a `silent` flag
- read/write grades in `value:date` format and adjust catalog output

## Testing
- `g++ -std=c++17 main.cpp Elev.cpp Materie.cpp Absente.cpp IO.cpp Nota.cpp -o main_test`

------
https://chatgpt.com/codex/tasks/task_e_68413f69eb708322907b1a2b365ed07e